### PR TITLE
Add option to load defaults as env variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,25 @@ Whenever you import the `gridemissions` module, the key-value pairs stored in `c
 ### `logging.conf`
 This file is also read when you import the `gridemissions` module and configures different loggers. We use the built-in `logging` module from the standard Python library. You can edit this file to control logging, and/or re-configure loggers programmatically after loading the gridemissions module.
 
+### Default Values
+
+Default values (such as configuration paths) can be set with environment variables.
+
+```bash
+export GRIDEMISSIONS_CONFIG_DIR_PATH="$HOME/.config/gridemissions_test"
+```
+
+#### Supported Environment Variables
+
+```text
+GRIDEMISSIONS_CONFIG_DIR_PATH:      the configuration directory (default: "$HOME/.config/gridemissions")
+GRIDEMISSIONS_LOG_CONFIG_FILE_PATH: the file used to store logging (default: "$HOME/.config/gridemissions/logging.conf")
+GRIDEMISSIONS_CONFIG_FILE_PATH:     the configuration file (default: "$HOME/.config/gridemissions/config.json")
+GRIDEMISSIONS_DEFAULT_LOGGING_CONF: the default logging configuration (default can be read within ./src/gridemissions/configure.py")
+GRIDEMISSIONS_DATA_DIR_PATH:        the data directory (default: "$HOME/data/gridemissions")
+GRIDEMISSIONS_TMP_DIR_PATH:         the temporary data directory (default: "$HOME/tmp/gridemissions")
+```
+
 ## Documentation
 Documentation uses [Sphinx](https://www.sphinx-doc.org/en/master/) and was generated in the `docs` folder. Open the index.html file in a browser to view the documentation. To re-generate the documentation you shoud be able to simply do
 ```

--- a/test/test_configure.py
+++ b/test/test_configure.py
@@ -1,0 +1,63 @@
+import importlib
+import os
+import shutil
+import unittest
+from pathlib import Path
+
+import gridemissions
+
+
+class TestEnvironmentVariables(unittest.TestCase):
+    """Test the interaction between environment variables and the configuration."""
+    test_dir_path = Path.home().joinpath(".config/gridemissions_test")
+    # A map of test environment variables to their value.
+    test_env_variables = {
+        "GRIDEMISSIONS_CONFIG_DIR_PATH": str(test_dir_path)
+    }
+    loaded_configure = gridemissions.configure
+
+    @classmethod
+    def reload_configure(cls):
+        """Reload the configure file."""
+        cls.loaded_configure = importlib.reload(cls.loaded_configure)
+
+    def setUp(self) -> None:
+        """Called before each test."""
+        super().setUp()
+        self.reload_configure()
+
+    def test_default_variable(self):
+        """Test the default behaviour of an environment variable."""
+        expected_path = Path.home().joinpath(".config/gridemissions")
+
+        # The initialized config directory should be the same as the default directory.
+        assert str(self.loaded_configure.CONFIG_DIR_PATH) == str(expected_path)
+
+    def test_declared_variable(self):
+        """Test using a declared environment variable, interpreted as a path."""
+        # Get the test environment, and set it as default.
+        test_var = "GRIDEMISSIONS_CONFIG_DIR_PATH"
+        os.environ[test_var] = self.test_env_variables.get(test_var)
+
+        # Reload the configuration to propagate the new environment variable.
+        self.reload_configure()
+
+        # The initialized config directory should be the same as the new test directory.
+        assert str(self.loaded_configure.CONFIG_DIR_PATH) == str(self.test_dir_path)
+
+    def tearDown(self) -> None:
+        """Called after each test."""
+        super().tearDown()
+
+        # Remove any set environment variables.
+        for env in self.test_env_variables:
+            try:
+                del os.environ[env]
+            except KeyError:
+                pass
+
+        # Remove the test directory.
+        try:
+            shutil.rmtree(self.test_dir_path)
+        except FileNotFoundError:
+            pass


### PR DESCRIPTION
Allow the user to specify environment variables to configure the default
behavior when initially loading the module.

Signed-off-by: Elijah J. Passmore <elijahjpassmore@elijahjpassmore.com>